### PR TITLE
Adding Start And Stop token detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+build

--- a/README.rst
+++ b/README.rst
@@ -40,3 +40,74 @@ Installation
 
  - launch the ``cron_calendar`` script, and authenticate as
    indicated. (you only have to do this step once)
+
+Synthax for commands
+--------------------
+
+The description field accept severals tokens to launch commands,
+Those token can be defined in configuration file
+
+**1. No token at all**
+
+Without any token each no-empty line will be executed separately at the start of the google calendar event
+
+*To note:*
+  * Several commands can be added per event, those will be programmed as independant AT command at start time
+
+**2. Comment token '#'**
+
+This allow to comment your commands meaning::
+
+    # This is a comment that will be ignored
+
+**3. Start-Stop tokens**
+
+Those tokens(configurable in config file) are followed by command that will be launched respectively to start of the event and to the end of the event::
+
+    start: <cmd_launch_at_start>
+    stop: <cmd_launch_at_end>
+
+*To note:*
+ * Commands 'start/stop' can be used several time per event, those will be
+   programmed as independant AT command
+
+
+**4. IF/ELSE token**
+
+Those token allow inline in description field to condition execution of 2 commands
+according to the result of third one(test_command)::
+
+    if test_command return 0     then the test is PASSED and start/stop command can be launched (if defined)
+    if test_command return other then the test is FAILED and else_start/else_stop command can be launched (if defined)
+
+* For example description could look like::
+
+    start: <start_commandA>
+    if_start: <test_commandB>
+    else_start: <start_commandC>
+
+    stop: <stop_commandD>
+    if_stop: <test_commandE>
+    else_stop: <stop_commandF>
+
+* This would be traduce as following pseudo code::
+
+    -- at start time --
+    IF test_commandB == 0:
+      start_commandA
+    ELSE:
+      start_commandC
+
+    -- at stop time --
+    IF test_commandE == 0:
+      start_commandD
+    ELSE:
+      start_commandF
+
+*To note:*
+ * IF/ELSE mechanisme is triggered if 'if_<start/stop>' is used
+ * This use bash synthax '&&, ||', AT command should be launch as bash commands
+ * If 'if_<start/stop>' token is used several time, only the first one will be used as test_comman
+
+
+

--- a/bin/cron_calendar
+++ b/bin/cron_calendar
@@ -24,6 +24,7 @@ import sys
 from cron_calendar_lib import CronCalendar
 import ConfigParser
 import signal
+import logging, logging.handlers
 
 def get_args(argv):
     import argparse
@@ -39,12 +40,44 @@ def get_args(argv):
                         dest="conf",
                         help="Provide the path to an alternate configuration file.")
 
-    parser.add_argument('--dryrun', action="store_true",
+    parser.add_argument('-d','--dryrun', action="store_true",
+                        dest="dryrun",
                         help="Query the calendar but doesn't program the at daemon.")
 
-
+    parser.add_argument('-l','--log', action="store_true",
+                        dest="log",
+                        help="Output will be logged in file(log file path is defined in config file )")
 
     return parser.parse_args(argv[1:])
+
+def create_logger(debug, loggername, log_file_enable, filename):
+    # Logger
+    logger = logging.getLogger(loggername)
+    logger.setLevel(logging.DEBUG)  # Only allow debug
+    formatter = logging.Formatter('%(name)s - %(levelname)s - %(funcName)s - %(message)s')
+
+    # STREAM CHANNEL - STDOUT
+    stream = logging.StreamHandler()
+    stream.setFormatter(formatter)
+    if debug:
+        stream.setLevel(logging.DEBUG)
+    else:
+        stream.setLevel(logging.INFO)
+    logger.addHandler(stream)
+
+    # ROTATING CHANNEL
+    if log_file_enable:
+        rf = logging.handlers.RotatingFileHandler(filename, mode='a', maxBytes=1000000, backupCount=5)
+        formatter_file = logging.Formatter('%(name)s - %(levelname)s - %(asctime)-15s - %(funcName)s - %(message)s')
+        rf.setFormatter(formatter_file)
+        if debug:
+            rf.setLevel(logging.DEBUG)
+        else:
+            rf.setLevel(logging.INFO)
+        logger.addHandler(rf)
+
+    return logger
+
 
 def main(argv):
     # Make sure the process is killed if last more than 50s.
@@ -64,7 +97,11 @@ def main(argv):
     if not read:
         sys.exit("No configuration found.\nTried : %s" % conf_files)
 
+    logging_filename=conf.get("storage", "log_file")
+    logger = create_logger((args.verbose_level>=1), 'CronCalendar', args.log, logging_filename)
+
     app = CronCalendar(conf=conf,
+                       logger=logger,
                        verbose_level=args.verbose_level,
                        dryrun=args.dryrun)
     app.run()

--- a/cron_calendar.conf
+++ b/cron_calendar.conf
@@ -26,8 +26,21 @@ calendar_id: <YOUR_CALENDAR_ID>@group.calendar.google.com
 advance_minute: 5
 
 # Token for command matching
+# Start
+# Will be followed with command to launch at the start of the event range
 start_token: start:
+# Will be followed with test command to launch before the start command, if passing code==0 start command is executed, if failing code!=0 else_start command is launched
+if_start_token: if_start:
+# Will be followed with command to launch at the start of the event range
+else_start_token: else_start:
+
+# Stop
+# Will be followed with command to launch at the end of the event range
 stop_token: stop:
+# Will be followed with test command to launch before the stop command, if passing code==0 stop command is executed, if failing code!=0 else_stop command is launched
+if_stop_token: if_stop:
+# Will be followed with command to launch at the end of the event range
+else_stop_token: else_stop:
 
 [storage]
 # The google API will store the authorisation in this file

--- a/cron_calendar.conf
+++ b/cron_calendar.conf
@@ -25,6 +25,9 @@ calendar_id: <YOUR_CALENDAR_ID>@group.calendar.google.com
 # the future. You should set you cron delay to this value.
 advance_minute: 5
 
+# Token for command matching
+start_token: start:
+stop_token: stop:
 
 [storage]
 # The google API will store the authorisation in this file

--- a/cron_calendar.conf
+++ b/cron_calendar.conf
@@ -37,6 +37,8 @@ credential_file: ~/.cron_calendar.dat
 # several times the same event.
 shelve_file: ~/.cron_calendar.shelve
 
+# Rotating Log file when requested by -l, --logger option
+log_file: /var/log/cron_calendar.log
 
 [google_api]
 # Get you own keys from google developper's web site:

--- a/cron_calendar_lib/cron_calendar.py
+++ b/cron_calendar_lib/cron_calendar.py
@@ -158,9 +158,10 @@ class CronCalendar:
         cmd_str = event[cmd]["dateTime"]
         cmd_dt = from_RFC3339(cmd_str)
         cmd_dt_utc = utc_from_RFC3339(cmd_str)
-        if not (dt_utctime_min <= cmd_dt_utc < dt_utctime_max):
-            if self.verbose_level >= 1:
-                print "{} time not inside boundaries".format(cmd)
+        if (cmd == "start") and not(dt_utctime_min <= cmd_dt_utc < dt_utctime_max):
+            logger.debug("{} time not inside boundaries(min<=dt<max)".format(cmd))
+        elif (cmd == "end") and not (dt_utctime_min < cmd_dt_utc <= dt_utctime_max):
+            logger.debug("{} time not inside boundaries(min<dt<=max)".format(cmd))
         else:
             description_str = event.get("description")
             summary_str = event.get("summary")

--- a/cron_calendar_lib/cron_calendar.py
+++ b/cron_calendar_lib/cron_calendar.py
@@ -77,9 +77,11 @@ class CronCalendar:
 
     def __init__(self,
                  conf,
+                 logger,
                  verbose_level=0,
                  dryrun=False):
         self.conf = conf
+        self.logger = logger
         self.verbose_level = verbose_level
         self.dryrun = dryrun
 
@@ -129,22 +131,19 @@ class CronCalendar:
     def __match_stop(self, at, event, dt_utctime_min, dt_utctime_max):
         " Try to match Stop token in the decription field of event, if match programm At with command, return True, else False "
         cmdToken = self.conf.get("general", "stop_token")
-        if self.verbose_level >= 1:
-            print "--match_stop with token: {}".format(cmdToken)
+        logger.debug("--match_stop with token: {}".format(cmdToken))
         re_cmd = re.compile(self.tokenMatchRegExp.format(cmdToken), re.VERBOSE|re.IGNORECASE)
         return self.__match_cmd(at, event, dt_utctime_min, dt_utctime_max, "end", re_cmd)
 
     def __match_start(self, at, event, dt_utctime_min, dt_utctime_max):
         " Try to match Start token in the decription field of event, if match programm At with command, return True, else False "
         cmdToken = self.conf.get("general", "start_token")
-        if self.verbose_level >= 1:
-            print "--match_start with token: {}".format(cmdToken)
+        logger.debug("--match_start with token: {}".format(cmdToken))
         re_cmd = re.compile(self.tokenMatchRegExp.format(cmdToken), re.VERBOSE|re.IGNORECASE)
         return self.__match_cmd(at, event, dt_utctime_min, dt_utctime_max, "start", re_cmd)
 
     def __match_none(self, at, event, dt_utctime_min, dt_utctime_max):
-        if self.verbose_level >= 1:
-            print "--match_none"
+        logger.debug("--match_none")
         "Run whatever is in the description field of event, if match programm At with command, return True, else False "
         re_cmd = re.compile(self.tokenMatchRegExp.format(""), re.VERBOSE|re.IGNORECASE)
         return self.__match_cmd(at, event, dt_utctime_min, dt_utctime_max, "start", re_cmd)
@@ -166,8 +165,7 @@ class CronCalendar:
             description_str = event.get("description")
             summary_str = event.get("summary")
             if not description_str:
-                if self.verbose_level >= 1:
-                    print "No command for [{}] at {}".format(summary_str, str(cmd_dt))
+                logger.debug("No command for [{}] at {}".format(summary_str, str(cmd_dt)))
             else:
                 for line in description_str.split("\n"):
                     match = reg_comp.match(line)
@@ -182,8 +180,7 @@ class CronCalendar:
                             at.run_at(cmd_dt, match.group('cmd_match'))
                         return True
                     else:
-                        if self.verbose_level >= 1:
-                            print "Line: '{}' doesn't match".format(line)
+                        logger.debug("Line: '{}' doesn't match".format(line))
         return False
 
     def __program_at(self,
@@ -208,14 +205,13 @@ class CronCalendar:
         dt_utctime_min, dt_utctime_max = self.__get_query_utc_dt()
 
         if dt_utctime_min == dt_utctime_max:
-            print "Nothing to query"
+            logger.info("Nothing to query")
         else:
 
             time_min = get_RFC3339(dt_utctime_min)
             time_max = get_RFC3339(dt_utctime_max)
 
-            if self.verbose_level >= 1:
-                print "Querying calendar from", time_min, "to", time_max
+            logger.debug("Querying calendar from", time_min, "to", time_max)
             req = self.service.events().list(calendarId=self.conf.get("general", "calendar_id"),
                                              singleEvents=True,  # Make sure regular events are expanded
                                              orderBy="startTime",


### PR DESCRIPTION
Add "Start" and "Stop" token detection in event's description field:
- Those tokens should begin the line with or without space before after 
  (see RegExp used on each lines in cron_calendar lib)
- Tokend are definable in config file with new config keywords "start_token:/stop_token:"(sample added in cron_calendar.conf)
- Start token will be programmed in AT to execute at the beginning of the event
- Stop token will be programmed in AT to execute at the end of the event

To note:  If no Start token, and no Stop token are detected, compatibility is maintained and full descritpion will be used as rough AT command
